### PR TITLE
Optimize tasks notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ CELERYBEAT_SCHEDULE["skillfarm_update_all_skillfarm"] = {
 
 CELERYBEAT_SCHEDULE["skillfarm_check_skillfarm_notifications"] = {
     "task": "skillfarm.tasks.check_skillfarm_notifications",
-    "schedule": crontab(minute=0, hour="*/12"),
+    "schedule": crontab(minute=0, hour="*/24"),
 }
 ```
 
@@ -102,12 +102,11 @@ With the Following IDs you can set up the permissions for the Skillfarm
 
 The Following Settings can be setting up in the `local.py`
 
-| Setting Name                      | Descriptioon                                           | Default       |
-| --------------------------------- | ------------------------------------------------------ | ------------- |
-| `SKILLFARM_APP_NAME`              | Set the name of the APP                                | `"Skillfarm"` |
-| `SKILLFARM_LOGGER_USE`            | Set to use own Logger File `True/False`                | `False`       |
-| `SKILLFARM_STALE_STATUS`          | Set the Stale Status for Skillfarm Character in hours  | `3`           |
-| `SKILLFARM_NOTIFICATION_COOLDOWN` | Number of days to wait before resending a notification | `3`           |
+| Setting Name             | Descriptioon                                          | Default       |
+| ------------------------ | ----------------------------------------------------- | ------------- |
+| `SKILLFARM_APP_NAME`     | Set the name of the APP                               | `"Skillfarm"` |
+| `SKILLFARM_LOGGER_USE`   | Set to use own Logger File `True/False`               | `False`       |
+| `SKILLFARM_STALE_STATUS` | Set the Stale Status for Skillfarm Character in hours | `3`           |
 
 If you set up SKILLFARM_LOGGER_USE to `True` you need to add the following code below:
 

--- a/skillfarm/app_settings.py
+++ b/skillfarm/app_settings.py
@@ -46,3 +46,6 @@ SKILLFARM_STALE_STATUS = clean_setting("SKILLFARM_STALE_STATUS", 3)
 
 # Set Notification Cooldown in Days
 SKILLFARM_NOTIFICATION_COOLDOWN = clean_setting("SKILLFARM_NOTIFICATION_COOLDOWN", 3)
+
+# Global timeout for tasks in seconds to reduce task accumulation during outages.
+SKILLFARM_TASKS_TIME_LIMIT = clean_setting("SKILLFARM_TASKS_TIME_LIMIT", 7200)

--- a/skillfarm/task_helper.py
+++ b/skillfarm/task_helper.py
@@ -3,58 +3,14 @@ Skillfarm Helper
 """
 
 import time
-from functools import wraps
 
 from bravado.exception import HTTPNotModified
-from celery import signature
-from celery_once import AlreadyQueued
 
 from django.core.cache import cache
 
 from skillfarm.hooks import get_extension_logger
 
 logger = get_extension_logger(__name__)
-
-
-def enqueue_next_task(chain):
-    """
-    Queue next task, and attach the rest of the chain to it.
-    """
-    while len(chain):
-        _t = chain.pop(0)
-        _t = signature(_t)
-        _t.kwargs.update({"chain": chain})
-        try:
-            _t.apply_async(priority=9)
-        except AlreadyQueued:
-            # skip this task as it is already in the queue
-            logger.debug("Skipping task as its already queued %s", _t)
-            continue
-        break
-
-
-def no_fail_chain(func):
-    """
-    Decorator to chain tasks provided in the chain kwargs regardless of task failures.
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        excp = None
-        _ret = None
-        try:
-            _ret = func(*args, **kwargs)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            excp = e
-        finally:
-            _chn = kwargs.get("chain", [])
-            enqueue_next_task(_chn)
-            if excp:
-                raise excp
-        return _ret
-
-    return wrapper
-
 
 MAX_ETAG_LIFE = 60 * 60 * 24 * 7  # 7 Days
 

--- a/skillfarm/tasks.py
+++ b/skillfarm/tasks.py
@@ -4,7 +4,7 @@ import datetime
 
 # Third Party
 # pylint: disable=no-name-in-module
-from celery import shared_task
+from celery import chain, shared_task
 
 from django.utils import timezone
 from django.utils.html import format_html
@@ -13,9 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from allianceauth.notifications import notify
 from allianceauth.services.tasks import QueueOnce
 
-from skillfarm.app_settings import (
-    SKILLFARM_STALE_STATUS,
-)
+from skillfarm import app_settings
 from skillfarm.decorators import when_esi_is_available
 from skillfarm.hooks import get_extension_logger
 from skillfarm.models.skillfarm import (
@@ -23,9 +21,24 @@ from skillfarm.models.skillfarm import (
     CharacterSkillqueueEntry,
     SkillFarmAudit,
 )
-from skillfarm.task_helper import enqueue_next_task, no_fail_chain
 
 logger = get_extension_logger(__name__)
+
+MAX_RETRIES_DEFAULT = 3
+
+# Default params for all tasks.
+TASK_DEFAULTS = {
+    "time_limit": app_settings.SKILLFARM_TASKS_TIME_LIMIT,
+    "max_retries": MAX_RETRIES_DEFAULT,
+}
+
+# Default params for tasks that need run once only.
+TASK_DEFAULTS_ONCE = {**TASK_DEFAULTS, **{"base": QueueOnce}}
+
+_update_skillfarm_params = {
+    **TASK_DEFAULTS_ONCE,
+    **{"once": {"keys": ["character_id"], "graceful": True}},
+}
 
 
 @shared_task
@@ -38,38 +51,43 @@ def update_all_skillfarm(runs: int = 0):
     logger.info("Queued %s Skillfarm Updates", runs)
 
 
-@shared_task(bind=True, base=QueueOnce)
+@shared_task(**_update_skillfarm_params)
 def update_character_skillfarm(
-    self, character_id, force_refresh=False
+    character_id, force_refresh=False
 ):  # pylint: disable=unused-argument
     character = SkillFarmAudit.objects.get(character__character_id=character_id)
-    skip_date = timezone.now() - datetime.timedelta(hours=SKILLFARM_STALE_STATUS)
+
+    # Settings for the Task Queue
     que = []
+    skip_date = timezone.now() - datetime.timedelta(
+        hours=app_settings.SKILLFARM_STALE_STATUS
+    )
     mindt = timezone.now() - datetime.timedelta(days=7)
+    priority = 7
+
     logger.debug(
         "Processing Audit Updates for %s", format(character.character.character_name)
     )
     if (character.last_update_skillqueue or mindt) <= skip_date or force_refresh:
-        que.append(update_char_skillqueue.si(character_id, force_refresh=force_refresh))
+        que.append(
+            update_char_skillqueue.si(character_id, force_refresh=force_refresh).set(
+                priority=priority
+            )
+        )
 
     if (character.last_update_skills or mindt) <= skip_date or force_refresh:
-        que.append(update_char_skills.si(character_id, force_refresh=force_refresh))
+        que.append(
+            update_char_skills.si(character_id, force_refresh=force_refresh).set(
+                priority=priority
+            )
+        )
 
-    enqueue_next_task(que)
-
+    chain(que).apply_async()
     logger.debug("Queued %s Tasks for %s", len(que), character.character.character_name)
 
 
-@shared_task(
-    bind=True,
-    base=QueueOnce,
-    once={"graceful": False, "keys": ["character_id"]},
-    name="tasks.update_char_skillqueue",
-)
-@no_fail_chain
-def update_char_skillqueue(
-    self, character_id, force_refresh=False, chain=[]
-):  # pylint: disable=unused-argument, dangerous-default-value
+@shared_task(**_update_skillfarm_params)
+def update_char_skillqueue(character_id, force_refresh=False):
     character = SkillFarmAudit.objects.get(character__character_id=character_id)
     CharacterSkillqueueEntry.objects.update_or_create_esi(
         character, force_refresh=force_refresh
@@ -78,16 +96,8 @@ def update_char_skillqueue(
     character.save()
 
 
-@shared_task(
-    bind=True,
-    base=QueueOnce,
-    once={"graceful": False, "keys": ["character_id"]},
-    name="tasks.update_char_skills",
-)
-@no_fail_chain
-def update_char_skills(
-    self, character_id, force_refresh=False, chain=[]
-):  # pylint: disable=unused-argument, dangerous-default-value
+@shared_task(**_update_skillfarm_params)
+def update_char_skills(character_id, force_refresh=False):
     character = SkillFarmAudit.objects.get(character__character_id=character_id)
     CharacterSkill.objects.update_or_create_esi(character, force_refresh=force_refresh)
     character.last_update_skills = timezone.now()
@@ -95,10 +105,9 @@ def update_char_skills(
 
 
 # pylint: disable=unused-argument, too-many-locals
-@shared_task(bind=True, base=QueueOnce)
-def check_skillfarm_notifications(self, runs: int = 0):
+@shared_task(**TASK_DEFAULTS_ONCE)
+def check_skillfarm_notifications(runs: int = 0):
     characters = SkillFarmAudit.objects.select_related("character").all()
-    warnings = {}
     notified_characters = []
 
     # Create a dictionary to map main characters to their alts
@@ -114,40 +123,45 @@ def check_skillfarm_notifications(self, runs: int = 0):
     for main_character, alts in main_to_alts.items():
         msg_items = []
         for alt in alts:
-            if alt.notification and not alt.is_cooldown:
+            if alt.notification:
                 skill_names = alt.get_finished_skills()
                 if skill_names:
                     # Create and Add Notification Message
                     msg = alt._generate_notification(skill_names)
                     msg_items.append(msg)
                     notified_characters.append(alt)
+            else:
+                # Reset Settings for Alts that have no notification enabled
+                alt.notification_sent = False
+                alt.last_notification = None
+                alt.save()
+
         if msg_items:
             # Add each message to Main Character
-            warnings[main_character] = "\n".join(msg_items)
-
-    if warnings:
-        for main_character, msg in warnings.items():
+            notifiy_message = "\n".join(msg_items)
             logger.debug(
                 "Skilltraining has been finished for %s Skills: %s",
                 main_character.character_name,
-                msg,
+                main_character,
             )
             title = _("Skillfarm Notifications")
             full_message = format_html(
-                "Following Skills have finished training: \n{}", msg
+                "Following Skills have finished training: \n{}", notifiy_message
             )
+
             notify(
                 title=title,
                 message=full_message,
                 user=main_character.character_ownership.user,
                 level="warning",
             )
-
-            # Set notification_sent to True for all characters that were notified
-            for character in notified_characters:
-                character.notification_sent = True
-                character.last_notification = timezone.now()
-                character.save()
-
             runs = runs + 1
+
+    if notified_characters:
+        # Set notification_sent to True for all characters that were notified
+        for character in notified_characters:
+            character.notification_sent = True
+            character.last_notification = timezone.now()
+            character.save()
+
     logger.info("Queued %s Skillfarm Notifications", runs)

--- a/skillfarm/tasks.py
+++ b/skillfarm/tasks.py
@@ -3,7 +3,6 @@
 import datetime
 
 # Third Party
-# pylint: disable=no-name-in-module
 from celery import chain, shared_task
 
 from django.utils import timezone
@@ -41,7 +40,7 @@ _update_skillfarm_params = {
 }
 
 
-@shared_task
+@shared_task(**TASK_DEFAULTS_ONCE)
 @when_esi_is_available
 def update_all_skillfarm(runs: int = 0):
     characters = SkillFarmAudit.objects.select_related("character").all()
@@ -52,6 +51,7 @@ def update_all_skillfarm(runs: int = 0):
 
 
 @shared_task(**_update_skillfarm_params)
+@when_esi_is_available
 def update_character_skillfarm(
     character_id, force_refresh=False
 ):  # pylint: disable=unused-argument


### PR DESCRIPTION
## Pull Request Template

Please include a summary of the changes and the related issue number (if applicable).

## Description

### Changed

This pull request includes several changes to improve the task scheduling and handling in the Skillfarm application. The most important changes involve updating task parameters, removing redundant functions, and adjusting the task scheduling intervals.

Improvements to task scheduling and handling:

* [`skillfarm/tasks.py`](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L6-R6): Updated task parameters to include default settings for task time limits and retries, and replaced the `no_fail_chain` decorator with direct chaining using `celery.chain`. [[1]](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L6-R6) [[2]](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L16-R43) [[3]](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L41-R90) [[4]](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L81-L101) [[5]](diffhunk://#diff-5598b33f0396639168996fda9093f6a5332949cd545b82ece833173258215350L117-L152)
* [`skillfarm/task_helper.py`](diffhunk://#diff-c1ed1058dbd918de764e443b4b2c7c92d600bbcb6da4d77d599c850db2f96619L6-L58): Removed the `enqueue_next_task` and `no_fail_chain` functions as they are no longer needed.

Configuration updates:

* [`skillfarm/app_settings.py`](diffhunk://#diff-2e686c2c86572b75e4a7c629ad227274146efb0999305e8e0d865189fe6269d2R49-R51): Added a new setting `SKILLFARM_TASKS_TIME_LIMIT` to define a global timeout for tasks in seconds.

### Type of Changes
Please select the type of changes made in this pull request:
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation Update
- [ ] Other (please specify):

### Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/geuthur/aa-skillfarm/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] All new and existing tests passed.
