### PR TITLE
[CHANGE] `DownTimeError` Will no longer send out warning logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Section Order:
 ### Removed
 -->
 
+### Changed
+
+- `DownTimeError` Will no longer send out warning logs
+
 ## [3.0.0] - 2026-05-08
 
 > [!IMPORTANT]

--- a/skillfarm/providers.py
+++ b/skillfarm/providers.py
@@ -95,7 +95,7 @@ def retry_task_on_esi_error(task: Task):
     - Rate limit errors (ESIBucketLimitException)
     - HTTPError with status codes 502, 503, 504 (server errors)
     - Request errors (RequestError)
-    - Downtime errors (DownTimeError)
+    - Downtime errors (DownTimeError, e.g. ESI's daily downtime from 11:00 to 11:15 UTC)
 
     :param task: Celery Task instance
     :return: Context manager that retries the task on ESI errors.
@@ -105,12 +105,13 @@ def retry_task_on_esi_error(task: Task):
     def retry(exc: Exception, retry_after: float, issue: str):
         backoff_jitter = int(random.uniform(2, 5) ** task.request.retries)
         countdown = retry_after + backoff_jitter
-        logger.warning(
-            "ESI Error encountered: %s. Retrying after %.2f seconds. Issue: %s",
-            str(exc),
-            countdown,
-            issue,
-        )
+        if not isinstance(exc, DownTimeError):
+            logger.warning(
+                "ESI Error encountered: %s. Retrying after %.2f seconds. Issue: %s",
+                str(exc),
+                countdown,
+                issue,
+            )
         raise task.retry(countdown=countdown, exc=exc)
 
     def daily_downtime():


### PR DESCRIPTION
## Description

### Changed
- `DownTimeError` Will no longer send out warning logs

## Type of Changes
Please select the type of changes made in this pull request:
- [ ] Bug Fix (non-breaking change which fixes an Issue)
- [ ] New Feature (non-breaking change)
- [ ] Other (please specify):

## Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/Geuthur/aa-skillfarm/blob/master/CODE_OF_CONDUCT.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
