### PR TITLE
[FIX] missing skill and skillqueue update methods in SkillFarmAudit model

### DIFF
--- a/skillfarm/models/skillfarmaudit.py
+++ b/skillfarm/models/skillfarmaudit.py
@@ -29,6 +29,7 @@ from skillfarm.managers.characterskill import SkillManager
 from skillfarm.managers.characterupdatestatus import UpdateStatusManager
 from skillfarm.managers.skillfarmaudit import SkillFarmManager
 from skillfarm.managers.skillqueue import SkillqueueManager
+from skillfarm.models.general import UpdateSectionResult
 from skillfarm.models.helpers.update_manager import (
     CharacterUpdateSection,
     UpdateManager,
@@ -175,6 +176,19 @@ class SkillFarmAudit(models.Model):
             skillname=", ".join(skill_names),
         )
         return str(msg)
+
+    # Task Area
+    def update_skills(self, force_refresh: bool = False) -> UpdateSectionResult:
+        """Update skills for this character."""
+        return self.skillfarm_skills.update_or_create_esi(
+            self, force_refresh=force_refresh
+        )
+
+    def update_skillqueue(self, force_refresh: bool = False) -> UpdateSectionResult:
+        """Update skillqueue for this character."""
+        return self.skillfarm_skillqueue.update_or_create_esi(
+            self, force_refresh=force_refresh
+        )
 
 
 class SkillFarmSetup(models.Model):

--- a/skillfarm/tests/managers/test_characterskill_manager.py
+++ b/skillfarm/tests/managers/test_characterskill_manager.py
@@ -46,10 +46,7 @@ class TestCharacterSkillManager(SkillFarmTestCase):
                 "unallocated_sp": 250000,
             },
         )
-        self.skillfarm_audit.skillfarm_skills.update_or_create_esi(
-            character=self.skillfarm_audit, force_refresh=False
-        )
-
+        self.skillfarm_audit.update_skills()
         self.assertSetEqual(
             set(
                 self.skillfarm_audit.skillfarm_skills.all().values_list(

--- a/skillfarm/tests/managers/test_skillqueue_manager.py
+++ b/skillfarm/tests/managers/test_skillqueue_manager.py
@@ -49,9 +49,7 @@ class TestSkillQueueManager(SkillFarmTestCase):
             ],
         )
         # when
-        self.skillfarm_audit.skillfarm_skillqueue.update_or_create_esi(
-            character=self.skillfarm_audit, force_refresh=False
-        )
+        self.skillfarm_audit.update_skillqueue()
         self.assertSetEqual(
             set(
                 self.skillfarm_audit.skillfarm_skillqueue.values_list(


### PR DESCRIPTION
## Description

### Fixed
- missing skill and skillqueue update methods in SkillFarmAudit model

## Type of Changes
Please select the type of changes made in this pull request:
- [x] Bug Fix (non-breaking change which fixes an Issue)
- [ ] New Feature (non-breaking change)
- [ ] Other (please specify):

## Checklist
Please ensure the following before submitting your pull request:
- [x] I have read the [contributing guidelines](https://github.com/Geuthur/aa-skillfarm/blob/master/CODE_OF_CONDUCT.md).
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] All new and existing tests passed.
